### PR TITLE
Fix: Shell steps require a shell definition

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -13,3 +13,4 @@ runs:
     - uses: actions/checkout@v3
     - id: gerrit-checkout
       run: git fetch origin ${{ inputs.gerrit-refspec }} && git checkout FETCH_HEAD
+      shell: bash


### PR DESCRIPTION
Signed-off-by: Andrew Grimberg <agrimberg@linuxfoundation.org>
