### PR TITLE
CI: Update pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,18 +27,18 @@ repos:
           - --branch=production
 
   - repo: https://github.com/jorisroovers/gitlint
-    rev: v0.19.0dev
+    rev: v0.19.1
     hooks:
       - id: gitlint
 
   - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v3.0.0-alpha.5
+    rev: v3.0.0-alpha.9-for-vscode
     hooks:
       - id: prettier
         stages: [commit]
 
   - repo: https://github.com/adrienverge/yamllint.git
-    rev: v1.29.0
+    rev: v1.32.0
     hooks:
       - id: yamllint
         types: [yaml]


### PR DESCRIPTION
* github.com/jorisroovers/gitlint: updating v0.19.0dev -> v0.19.1
* github.com/pre-commit/mirrors-prettier:
    v3.0.0-alpha.5 -> v3.0.0-alpha.9-for-vscode
* github.com/adrienverge/yamllint: v1.29.0 -> v1.32.0

Signed-off-by: Andrew Grimberg <agrimberg@linuxfoundation.org>
