### PR TITLE
CI: Freeze pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,7 +7,7 @@ ci:
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.4.0
+    rev: f71fa2c1f9cf5cb705f73dffe4b21f7c61470ba9 # frozen: v4.4.0
     hooks:
       - id: trailing-whitespace
       - id: check-added-large-files
@@ -30,28 +30,28 @@ repos:
           - --branch=production
 
   - repo: https://github.com/jorisroovers/gitlint
-    rev: v0.19.1
+    rev: acc9d9de6369b76d22cb4167029d2035e8730b98 # frozen: v0.19.1
     hooks:
       - id: gitlint
 
   - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v3.0.0-alpha.9-for-vscode
+    rev: 6fd1ced85fc139abd7f5ab4f3d78dab37592cd5e # frozen: v3.0.0-alpha.9-for-vscode
     hooks:
       - id: prettier
         stages: [commit]
 
   - repo: https://github.com/adrienverge/yamllint.git
-    rev: v1.32.0
+    rev: b05e028c5881819161d11cb543fd96a30c06cceb # frozen: v1.32.0
     hooks:
       - id: yamllint
         types: [yaml]
 
   - repo: https://github.com/shellcheck-py/shellcheck-py
-    rev: v0.9.0.2
+    rev: 4bb61ddc1b4175565f8f975fd20d657f00f2bd53 # frozen: v0.9.0.2
     hooks:
       - id: shellcheck
 
   - repo: https://github.com/rhysd/actionlint
-    rev: v1.6.24
+    rev: fd7ba3c382e13dcc0248e425b4cbc3f1185fa3ee # frozen: v1.6.24
     hooks:
       - id: actionlint


### PR DESCRIPTION
* github.com/pre-commit/pre-commit-hooks: v4.4.0 -> v4.4.0 (frozen)
* github.com/jorisroovers/gitlint: v0.19.1 -> v0.19.1 (frozen)
* github.com/pre-commit/mirrors-prettier:
    v3.0.0-alpha.9-for-vscode -> v3.0.0-alpha.9-for-vscode (frozen)
* github.com/adrienverge/yamllint: v1.32.0 -> v1.32.0 (frozen)
* github.com/shellcheck-py/shellcheck-py: v0.9.0.2 -> v0.9.0.2 (frozen)

Signed-off-by: Andrew Grimberg <agrimberg@linuxfoundation.org>
