### PR TITLE
CI: Try amannn/action-semantic-pull-request

### DIFF
--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -4,6 +4,8 @@ name: Lint GitHub Actions workflows
 # yamllint disable-line rule:truthy
 on: [push, pull_request]
 
+permissions: read-all
+
 jobs:
   actionlint:
     runs-on: ubuntu-latest
@@ -16,6 +18,30 @@ jobs:
       - name: Check workflow files
         run: ${{ steps.get_actionlint.outputs.executable }} -color
         shell: bash
+
+  commit-message:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          # Requires the type to be capitlized, but accept any of the standard
+          # types
+          types: |
+            Fix
+            Feat
+            Chore
+            Docs
+            Style
+            Refactor
+            Perf
+            Test
+            Revert
+            CI
+            Build
+          validateSingleCommit: true
+          validateSingleCommitMatchesPrTitle: true
 
   pre-commit:
     runs-on: ubuntu-latest

--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -42,21 +42,3 @@ jobs:
             Build
           validateSingleCommit: true
           validateSingleCommitMatchesPrTitle: true
-
-  pre-commit:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
-        with:
-          python-version: "3.11"
-      - name: Run static analysis and format checkers (PR)
-        # yamllint disable-line rule:line-length
-        run: SKIP=actionlint pipx run pre-commit run --all-files --show-diff-on-failure
-        if: github.event_name != 'push'
-      - name: Run static analysis and format checkers (PUSH)
-        # Skip the no-commit-to-branch check on push as it's already too late
-        # and it should have come in via PR which _would_ have caught it
-        # yamllint disable-line rule:line-length
-        run: SKIP=actionlint,no-commit-to-branch pipx run pre-commit run --all-files --show-diff-on-failure
-        if: github.event_name != 'pull_request'


### PR DESCRIPTION
Give amannn/action-semantic-pull-request a try for validating PR commit
messages. If this works we can drop the custom pre-commit validator we
would have to otherwise use to use gitlint

Signed-off-by: Andrew Grimberg <agrimberg@linuxfoundation.org>
