### PR TITLE
Feat: Fall back to fetching change from Gerrit

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -6,6 +6,9 @@ inputs:
   gerrit-refspec:
     description: "The Gerrit refspec for the change, eg: refs/changes/YY/NNYY/Z"
     required: true
+  gerrit-project:
+    description: "The project in Gerrit"
+    required: true
   delay:
     description: "Delay in seconds to wait to make sure replication has finished. Default: 10s"
     required: false
@@ -56,5 +59,36 @@ runs:
         token: ${{ inputs.token }}
         submodules: ${{ inputs.submodules }}
     - id: gerrit-checkout
-      run: git fetch origin ${{ inputs.gerrit-refspec }} && git checkout FETCH_HEAD
-      shell: bash
+      shell: bash --noprofile --norc {0}
+      run: |
+        report_error_and_exit()
+        {
+          default="fatal: couldn't find remote ref ${{ inputs.gerrit-refspec }}"
+          message=${1:-$default}
+          echo "$message"
+          # Log GitHub annotation
+          echo "::error::$message"
+          exit 1
+        }
+
+        fetch_from_gerrit()
+        {
+          if [ "${GERRIT_URL}x" == "x" ] then
+            report_error_and_exit "$1"
+          fi
+
+          error=$(git fetch ${GERRIT_URL}${{ inputs.gerrit-project }} ${{ inputs.gerrit-refspec }} 2>&1 > /dev/null)
+          exit_code=$?
+          if [ $exit_code -ne 0 ]
+          then
+            report_error_and_exit "$error"
+          fi
+        }
+
+        error=$(git fetch origin ${{ inputs.gerrit-refspec }})
+        exit_code=$?
+        if [ $exit_code -ne 0 ]
+        then
+          fetch_from_gerrit "$error"
+        fi
+        git checkout FETCH_HEAD


### PR DESCRIPTION
Add a fallback for attempting to fetch a change directly from Gerrit if
the GitHub mirror has not yet caught up for some reason.

Signed-off-by: Andrew Grimberg <agrimberg@linuxfoundation.org>
