### PR TITLE
Fix: Move debug turn on

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -59,8 +59,10 @@ runs:
         token: ${{ inputs.token }}
         submodules: ${{ inputs.submodules }}
     - id: gerrit-checkout
-      shell: bash -x --noprofile --norc {0}
+      shell: bash --noprofile --norc {0}
       run: |
+        set -x
+
         report_error_and_exit()
         {
           default="fatal: couldn't find remote ref ${{ inputs.gerrit-refspec }}"


### PR DESCRIPTION
GitHub actions seems to have an issue with '-x' being passed to the bash
interpreter directly. Move it to a set call instead.

Signed-off-by: Andrew Grimberg <agrimberg@linuxfoundation.org>
