### PR TITLE
Fix: Force GHA Var for GERRIT_URL to be picked up

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -75,7 +75,7 @@ runs:
 
         fetch_from_gerrit()
         {
-          if [ "${GERRIT_URL}x" == "x" ]
+          if [ "${{ vars.GERRIT_URL }}x" == "x" ]
           then
             report_error_and_exit "$1"
           fi


### PR DESCRIPTION
For some reason the GHA variable GERRIT_URL is not showing up as a
defined ENV var, force define it via the ${{ vars.XXXX }} syntax

Signed-off-by: Andrew Grimberg <agrimberg@linuxfoundation.org>
