### PR TITLE
Chore: Update pre-commit hooks (frozen)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,13 +32,13 @@ repos:
       - id: gitlint
 
   - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: fc260393cc4ec09f8fc0a5ba4437f481c8b55dc1 # frozen: v3.0.3
+    rev: f12edd9c7be1c20cfa42420fd0e6df71e42b51ea # frozen: v4.0.0-alpha.8
     hooks:
       - id: prettier
         stages: [commit]
 
   - repo: https://github.com/adrienverge/yamllint.git
-    rev: b05e028c5881819161d11cb543fd96a30c06cceb # frozen: v1.32.0
+    rev: dd99a1c965b56027e9773442f41d3c58cc53c690 # frozen: v1.34.0
     hooks:
       - id: yamllint
         types: [yaml]


### PR DESCRIPTION
* github.com/pre-commit/mirrors-prettier: v3.0.3 -> v4.0.0-alpha.8 (frozen)
* github.com/adrienverge/yamllint.git: v1.32.0 -> v1.34.0 (frozen)

Signed-off-by: Andrew Grimberg <agrimberg@linuxfoundation.org>
