### PR TITLE
Fix: Check and update submodules if required

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -102,3 +102,8 @@ runs:
           fetch_from_gerrit "$error"
         fi
         git checkout FETCH_HEAD
+
+        if [ ${{ inputs.submodules }} ~= true|True ]
+        then
+          git submodule update
+        fi


### PR DESCRIPTION
The GHA workflow for ci verify process does not take into consideration the changes that include submodule updates. The correct way is to update the submodule before running JJB verify or any verify without which the verify would run on a stale submodule and not the latest.

This issue was caught while testing ORAN ci-man verify changes with global-job v0.90.0 updates for JJB 6.x.

Issue: RELENG-5139