### PR TITLE
Fix: GitHub repo checkout step can continue-on-error

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -57,7 +57,11 @@ runs:
     - id: delay-checkout
       run: sleep ${{ inputs.delay }}
       shell: bash
-    - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+    # For performance, prefer the local GitHub mirror/repository when available
+    - name: "GitHub Checkout [continue-on-error enabled]"
+      uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      # Could fail when Gerrit repository is newly created
+      continue-on-error: true
       with:
         fetch-depth: ${{ inputs.fetch-depth }}
         repository: ${{ inputs.repository }}


### PR DESCRIPTION
When a Gerrit repository is newly created, and possibly under other conditions, the GitHub repository checkout might fail. This can block verification jobs using the action from completing. Given the code has already been pulled from Gerrit, this should not prevent the action from continuing.