### PR TITLE
Fix: Use set-url to checkout Gerrit refspec

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -95,6 +95,12 @@ runs:
           fi
         }
 
+        error=$(git remote set-url origin "${{ inputs.gerrit-url }}/${{ inputs.gerrit-project }}")
+        if [ $exit_code -ne 0 ]
+        then
+          report_error_and_exit "$error"
+        fi
+
         error=$(git fetch origin ${{ inputs.gerrit-refspec }})
         exit_code=$?
         if [ $exit_code -ne 0 ]
@@ -102,6 +108,7 @@ runs:
           fetch_from_gerrit "$error"
         fi
         git checkout FETCH_HEAD
+        echo "DEBUG: FETCH_HEAD: $(git rev-parse HEAD)"
 
         if [[ ${{ inputs.submodules }} = [Tt]rue ]]
         then


### PR DESCRIPTION
The issue in the lfit/checkout-gerrit-change-action which attempts a github-like checkout first, and failure it no longer falls back to gerrit checkout for some reason. To fix this use the set-url to set the Gerrit remote.

The action expected to work with Gerrit repositories and not Github repos. The refspec would not be available on Github unless the change has been merged. Therefore the action in question should only attempt checkout from the Gerrit repo or fail with an error code.

The right order to checkout:
1. Set up the Gerrit remote git remote set-url origin "${{ inputs.gerrit-url }}/${{ inputs.gerrit-project }}"

2. Fetch the specific change git fetch origin "${{ inputs.gerrit-refspec }}"

3. Checkout the fetched change git checkout FETCH_HEAD

4. Verify we got the right commit echo "Checked out: $(git rev-parse HEAD)"